### PR TITLE
fix: Resolve infinite re-render loop in ProtectedRoute

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -18,7 +18,7 @@ export default function ProtectedRoute({ children }) {
       setLoading(false)
     }
     checkUser()
-  }, [navigate])
+  }, [])
 
   if (loading) {
     return <div>Cargando...</div>


### PR DESCRIPTION
The application was getting stuck in an infinite re-render loop caused by the `useEffect` hook in the `ProtectedRoute` component. The hook's dependency array included the `navigate` function from `react-router-dom`, causing the effect to re-run on every render.

This change corrects the dependency array to be empty (`[]`), ensuring the user authentication check runs only once when the component mounts. This breaks the cycle of re-renders and stabilizes the application.